### PR TITLE
chore: Update stop method in AudioPlayer to support pausing all players

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -125,7 +125,7 @@ class AudioPlayer(
         }
     }
 
-    fun stop(result: MethodChannel.Result) {
+    fun stop(result: MethodChannel.Result,pauseAll : Boolean) {
         stopListening()
         if (playerListener != null) {
             player?.removeListener(playerListener!!)
@@ -133,7 +133,11 @@ class AudioPlayer(
         isPlayerPrepared = false
         player?.stop()
         player?.release()
-        result.success(true)
+        if(!pauseAll){
+            result.success(true)
+        }
+
+
     }
 
 
@@ -141,9 +145,15 @@ class AudioPlayer(
         try {
             stopListening()
             player?.pause()
-            result.success(true)
+
+                result.success(true)
+
+
         } catch (e: Exception) {
-            result.error(Constants.LOG_TAG, "Failed to pause the player", e.toString())
+
+                result.error(Constants.LOG_TAG, "Failed to pause the player", e.toString())
+
+
         }
 
     }

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioWaveformsPlugin.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioWaveformsPlugin.kt
@@ -100,7 +100,7 @@ class AudioWaveformsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             Constants.stopPlayer -> {
                 val key = call.argument(Constants.playerKey) as String?
                 if (key != null) {
-                    audioPlayers[key]?.stop(result)
+                    audioPlayers[key]?.stop(result,false)
                 } else {
                     result.error(Constants.LOG_TAG, "Player key can't be null", "")
                 }
@@ -174,10 +174,10 @@ class AudioWaveformsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
             Constants.stopAllPlayers -> {
                 for ((key, _) in audioPlayers) {
-                    audioPlayers[key]?.stop(result)
+                    audioPlayers[key]?.stop(result,true)
                     audioPlayers[key] = null
                 }
-                result.success(true)
+                  result.success(true)
             }
             else -> result.notImplemented()
         }


### PR DESCRIPTION
- Fixed For Android: Submitting multiple result when calling stopAllPlayer(),
causing this issue.

Reply already submitted
io.flutter.embedding.engine.dart.DartMessenger$Reply.reply (DartMessenger.java:35)
io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.error (MethodChannel.java:14)
com.simform.audio_waveforms.AudioPlayer$startListening$1.run (AudioPlayer.java:80)
android.os.Handler.handleCallback (Handler.java:958)

